### PR TITLE
Update colophon.xhtml

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -12,7 +12,7 @@
 				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">The Son of the Wolf</i><br/>
-			was published in 1914 by<br/>
+			was published in 1900 by<br/>
 			<a href="https://en.wikipedia.org/wiki/Jack_London">Jack London</a>.</p>
 			<p>This ebook was produced for<br/>
 			<a href="https://standardebooks.org">Standard Ebooks</a><br/>


### PR DESCRIPTION
**Changed the publication date from 1914 to 1900.**

The Son of the Wolf (Jack London) was first published in 1900. 

**Sources:** 
- Internet Archive: https://archive.org/details/thesonofthewolf00londrich/page/n7/mode/2up?view=theater

- British Library: https://bll01.primo.exlibrisgroup.com/discovery/fulldisplay?docid=alma990022533630100000&context=L&vid=44BL_INST:BLL01&lang=en&search_scope=Not_BL_Suppress&adaptor=Local%20Search%20Engine&tab=LibraryCatalog&query=any,contains,The%20Son%20of%20the%20Wolf&sortby=title&facet=frbrgroupid,include,9021183035875064982&offset=200